### PR TITLE
Remove all reference to libvulpes/advanced rocketry

### DIFF
--- a/overrides/scripts/contenttweaker.zs
+++ b/overrides/scripts/contenttweaker.zs
@@ -30,8 +30,8 @@ new BlockBuilder().withHardnessAndResistance(1f, 0.5f).setRequiresTool().withHar
 new BlockBuilder().withHardnessAndResistance(1f, 0.5f).setRequiresTool().withHarvestTool(<tooltype:pickaxe>).withHarvestLevel(1).build("fluorite_block");
 new BlockBuilder().withHardnessAndResistance(1f, 0.5f).setRequiresTool().withHarvestTool(<tooltype:pickaxe>).withHarvestLevel(2).build("aluminium_casing");
 
-new FluidBuilder(false, 0xb3822601).build("kerosene");
-new FluidBuilder(false, 0xb3f2edbd).build("butane");
-new FluidBuilder(false, 0xb3942d22).build("fuel");
-new FluidBuilder(false, 0xb3b53f00).build("refined_fuel");
+//new FluidBuilder(false, 0xb3822601).build("kerosene");
+//new FluidBuilder(false, 0xb3f2edbd).build("butane");
+//new FluidBuilder(false, 0xb3942d22).build("fuel");
+//new FluidBuilder(false, 0xb3b53f00).build("refined_fuel");
 new FluidBuilder(false, 0xb3e0ffff).build("alumina_solution");

--- a/overrides/scripts/crafting/advancedrocketry.zs
+++ b/overrides/scripts/crafting/advancedrocketry.zs
@@ -1,45 +1,45 @@
-craftingTable.removeRecipe(<item:libvulpes:motor>);
-craftingTable.removeRecipe(<item:libvulpes:advanced_motor>);
-craftingTable.removeRecipe(<item:libvulpes:enhanced_motor>);
-craftingTable.removeRecipe(<item:libvulpes:elite_motor>);
-craftingTable.removeRecipe(<item:advancedrocketry:platepress>);
-craftingTable.removeRecipe(<item:libvulpes:coal_generator>);
-craftingTable.removeRecipe(<item:advancedrocketry:blastbrick>);
-craftingTable.removeRecipe(<item:advancedrocketry:arcfurnace>);
-craftingTable.removeRecipe(<item:libvulpes:structure_machine>);
-craftingTable.removeRecipe(<item:libvulpes:adv_structure_machine>);
+//craftingTable.removeRecipe(<item:libvulpes:motor>);
+//craftingTable.removeRecipe(<item:libvulpes:advanced_motor>);
+//craftingTable.removeRecipe(<item:libvulpes:enhanced_motor>);
+//craftingTable.removeRecipe(<item:libvulpes:elite_motor>);
+//craftingTable.removeRecipe(<item:advancedrocketry:platepress>);
+//craftingTable.removeRecipe(<item:libvulpes:coal_generator>);
+//craftingTable.removeRecipe(<item:advancedrocketry:blastbrick>);
+//craftingTable.removeRecipe(<item:advancedrocketry:arcfurnace>);
+//craftingTable.removeRecipe(<item:libvulpes:structure_machine>);
+//craftingTable.removeRecipe(<item:libvulpes:adv_structure_machine>);
 
-craftingTable.addShaped("basicmotor",
-  <item:libvulpes:motor>,[
-    [<tag:items:forge:plates/iron>,<tag:items:forge:plates/iron>,<tag:items:forge:plates/iron>],
-    [<item:immersiveengineering:coil_lv>,<item:contenttweaker:servo>,<tag:items:forge:rods/iron>],
-    [<tag:items:forge:sheetmetals/iron>,<tag:items:forge:rods/iron>,<tag:items:forge:sheetmetals/iron>]
-]);
+//craftingTable.addShaped("basicmotor",
+//  <item:libvulpes:motor>,[
+//    [<tag:items:forge:plates/iron>,<tag:items:forge:plates/iron>,<tag:items:forge:plates/iron>],
+//    [<item:immersiveengineering:coil_lv>,<item:contenttweaker:servo>,<tag:items:forge:rods/iron>],
+//    [<tag:items:forge:sheetmetals/iron>,<tag:items:forge:rods/iron>,<tag:items:forge:sheetmetals/iron>]
+//]);
 
-craftingTable.addShaped("advancedmotor",
-  <item:libvulpes:advanced_motor>,[
-    [<tag:items:forge:plates/steel>,<tag:items:forge:plates/steel>,<tag:items:forge:plates/steel>],
-    [<item:immersiveengineering:light_engineering>,<item:contenttweaker:servo>,<tag:items:forge:rods/steel>],
-    [<item:mekanism:steel_casing>,<item:mekanism:basic_control_circuit>,<item:mekanism:steel_casing>]
-]);
+//craftingTable.addShaped("advancedmotor",
+//  <item:libvulpes:advanced_motor>,[
+//    [<tag:items:forge:plates/steel>,<tag:items:forge:plates/steel>,<tag:items:forge:plates/steel>],
+//    [<item:immersiveengineering:light_engineering>,<item:contenttweaker:servo>,<tag:items:forge:rods/steel>],
+//    [<item:mekanism:steel_casing>,<item:mekanism:basic_control_circuit>,<item:mekanism:steel_casing>]
+//]);
 
-craftingTable.addShaped("enhancedmotor",
-  <item:libvulpes:enhanced_motor>,[
-    [<item:contenttweaker:coated_aluminium_sheet>,<item:contenttweaker:coated_aluminium_sheet>,<item:contenttweaker:coated_aluminium_sheet>],
-    [<item:immersiveengineering:heavy_engineering>,<item:contenttweaker:servo>,<item:contenttweaker:servo>],
-    [<item:contenttweaker:aluminium_casing>,<item:computercraft:computer_normal>,<item:contenttweaker:aluminium_casing>]
-]);
+//craftingTable.addShaped("enhancedmotor",
+//  <item:libvulpes:enhanced_motor>,[
+//    [<item:contenttweaker:coated_aluminium_sheet>,<item:contenttweaker:coated_aluminium_sheet>,<item:contenttweaker:coated_aluminium_sheet>],
+//    [<item:immersiveengineering:heavy_engineering>,<item:contenttweaker:servo>,<item:contenttweaker:servo>],
+//    [<item:contenttweaker:aluminium_casing>,<item:computercraft:computer_normal>,<item:contenttweaker:aluminium_casing>]
+//]);
+//
+//craftingTable.addShaped("elitemotor",
+//  <item:libvulpes:elite_motor>,[
+//    [<item:advancedrocketry:platetitaniumiridium>,<item:advancedrocketry:platetitaniumiridium>,<item:advancedrocketry:platetitaniumiridium>],
+//    [<item:mekanism:pellet_polonium>,<item:contenttweaker:servo>,<item:contenttweaker:servo>],
+//    [<item:appliedenergistics2:quartz_glass>,<item:computercraft:computer_normal>,<item:appliedenergistics2:quartz_glass>]
+//]);
 
-craftingTable.addShaped("elitemotor",
-  <item:libvulpes:elite_motor>,[
-    [<item:advancedrocketry:platetitaniumiridium>,<item:advancedrocketry:platetitaniumiridium>,<item:advancedrocketry:platetitaniumiridium>],
-    [<item:mekanism:pellet_polonium>,<item:contenttweaker:servo>,<item:contenttweaker:servo>],
-    [<item:appliedenergistics2:quartz_glass>,<item:computercraft:computer_normal>,<item:appliedenergistics2:quartz_glass>]
-]);
-
-craftingTable.addShaped("machinestructure",
-  <item:libvulpes:structure_machine>,[
-    [<tag:items:forge:ingots/titanium>,<item:contenttweaker:coated_aluminium_sheet>,<tag:items:forge:ingots/titanium>],
-    [<item:contenttweaker:coated_aluminium_sheet>,<item:immersiveengineering:sheetmetal_steel>,<item:contenttweaker:coated_aluminium_sheet>],
-    [<tag:items:forge:ingots/titanium>,<item:contenttweaker:coated_aluminium_sheet>,<tag:items:forge:ingots/titanium>]
-]);
+//craftingTable.addShaped("machinestructure",
+//  <item:libvulpes:structure_machine>,[
+//    [<tag:items:forge:ingots/titanium>,<item:contenttweaker:coated_aluminium_sheet>,<tag:items:forge:ingots/titanium>],
+//    [<item:contenttweaker:coated_aluminium_sheet>,<item:immersiveengineering:sheetmetal_steel>,<item:contenttweaker:coated_aluminium_sheet>],
+//    [<tag:items:forge:ingots/titanium>,<item:contenttweaker:coated_aluminium_sheet>,<tag:items:forge:ingots/titanium>]
+//]);

--- a/overrides/scripts/immersive_engineering.zs
+++ b/overrides/scripts/immersive_engineering.zs
@@ -64,21 +64,21 @@ import mods.immersivepetroleum.DistillationBuilder;
   1024
 );
 
-<recipetype:immersivepetroleum:cokerunit>.addRecipe(
-  "kerosene_refining",
-  <item:immersiveengineering:dust_aluminum>*1,
-  <item:mekanism:salt>*1,
-  <tag:fluids:forge:kerosene>*200,
-  <tag:fluids:forge:fuel>*150,
-  1024
-);
+//<recipetype:immersivepetroleum:cokerunit>.addRecipe(
+//  "kerosene_refining",
+//  <item:immersiveengineering:dust_aluminum>*1,
+//  <item:mekanism:salt>*1,
+//  <tag:fluids:forge:kerosene>*200,
+//  <tag:fluids:forge:fuel>*150,
+//  1024
+//);
 
-new DistillationBuilder()
-  .setOutputFluids([<fluid:contenttweaker:kerosene>*600,<fluid:mekanism:ethene>*200,<fluid:contenttweaker:butane>*100])
-  .setInputFluid(<tag:fluids:forge:lubricant>,2000)
-  .addByproduct(<item:immersiveengineering:dust_sulfur>, 0.1)
-  .setEnergyAndTime(2048,1)
-  .build("kerosene_cracking");
-
-<recipetype:immersiveengineering:refinery>.addRecipe("refined_fuel", <tag:fluids:forge:fuel> * 10, <tag:fluids:forge:butane> * 10, 1024, <fluid:contenttweaker:refined_fuel> * 10);
-<recipetype:immersiveengineering:refinery>.addRecipe("rocket_fuel", <tag:fluids:forge:refined_fuel> * 10, <tag:fluids:forge:oxygen> * 10, 1024, <fluid:advancedrocketry:rocket_fuel> * 5);
+//new DistillationBuilder()
+//  .setOutputFluids([<fluid:contenttweaker:kerosene>*600,<fluid:mekanism:ethene>*200,<fluid:contenttweaker:butane>*100])
+//  .setInputFluid(<tag:fluids:forge:lubricant>,2000)
+//  .addByproduct(<item:immersiveengineering:dust_sulfur>, 0.1)
+//  .setEnergyAndTime(2048,1)
+//  .build("kerosene_cracking");
+//
+//<recipetype:immersiveengineering:refinery>.addRecipe("refined_fuel", <tag:fluids:forge:fuel> * 10, <tag:fluids:forge:butane> * 10, 1024, <fluid:contenttweaker:refined_fuel> * 10);
+//<recipetype:immersiveengineering:refinery>.addRecipe("rocket_fuel", <tag:fluids:forge:refined_fuel> * 10, <tag:fluids:forge:oxygen> * 10, 1024, <fluid:advancedrocketry:rocket_fuel> * 5);

--- a/overrides/scripts/ore_unify.zs
+++ b/overrides/scripts/ore_unify.zs
@@ -40,9 +40,9 @@ craftingTable.removeRecipe(<item:tconstruct:copper_nugget>);
 craftingTable.removeRecipe(<item:tconstruct:copper_block>);
 craftingTable.removeRecipe(<item:create:copper_ingot>);
 craftingTable.removeRecipe(<item:create:copper_nugget>);
-craftingTable.removeRecipe(<item:libvulpes:ingotcopper>);
-craftingTable.removeRecipe(<item:libvulpes:nuggetcopper>);
-craftingTable.removeRecipe(<item:libvulpes:blockcopper>);
+//craftingTable.removeRecipe(<item:libvulpes:ingotcopper>);
+//craftingTable.removeRecipe(<item:libvulpes:nuggetcopper>);
+//craftingTable.removeRecipe(<item:libvulpes:blockcopper>);
 
 <recipetype:minecraft:smelting>.removeRecipe(<item:mekanism:ingot_copper>);
 <recipetype:minecraft:blasting>.removeRecipe(<item:mekanism:ingot_copper>);
@@ -52,8 +52,8 @@ craftingTable.removeRecipe(<item:libvulpes:blockcopper>);
 <recipetype:minecraft:blasting>.removeRecipe(<item:immersiveengineering:ingot_copper>);
 <recipetype:minecraft:smelting>.removeRecipe(<item:iceandfire:copper_ingot>);
 <recipetype:minecraft:blasting>.removeRecipe(<item:iceandfire:copper_ingot>);
-<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingotcopper>);
-<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingotcopper>);
+//<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingotcopper>);
+//<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingotcopper>);
 
 
 <recipetype:minecraft:blasting>.addRecipe("copperdustblast", <item:create:copper_ingot>,<tag:items:forge:dusts/copper>, 1.0, 100);
@@ -165,25 +165,25 @@ craftingTable.addShapeless("steelnuggettoingot", <item:immersiveengineering:ingo
 <recipetype:minecraft:blasting>.addRecipe("steeldustblast",<item:immersiveengineering:ingot_steel>,<tag:items:forge:dusts/steel>,1.0,100);
 
 // Aluminium
-<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingotaluminum>);
-<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingotaluminum>);
+//<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingotaluminum>);
+//<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingotaluminum>);
 
-craftingTable.removeRecipe(<item:libvulpes:ingotaluminum>);
-craftingTable.removeRecipe(<item:libvulpes:nuggetaluminum>);
-craftingTable.removeRecipe(<item:libvulpes:blockaluminum>);
-craftingTable.removeRecipe(<item:immersiveengineering:nugget_aluminum>);
-craftingTable.removeRecipe(<item:immersiveengineering:ingot_aluminum>);
-craftingTable.removeRecipe(<item:immersiveengineering:storage_aluminum>);
-
-craftingTable.addShapeless("aluingottoblock",<item:immersiveengineering:storage_aluminum>,[<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>]);
-craftingTable.addShapeless("alublocktoingot",<item:immersiveengineering:ingot_aluminum>*9,[<tag:items:forge:storage_blocks/aluminum>]);
-craftingTable.addShapeless("aluingottonugget",<item:immersiveengineering:nugget_aluminum>*9,[<tag:items:forge:ingots/aluminum>]);
-craftingTable.addShapeless("alunuggettoingot",<item:immersiveengineering:ingot_aluminum>,[<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>]);
-
+//craftingTable.removeRecipe(<item:libvulpes:ingotaluminum>);
+//craftingTable.removeRecipe(<item:libvulpes:nuggetaluminum>);
+//craftingTable.removeRecipe(<item:libvulpes:blockaluminum>);
+//craftingTable.removeRecipe(<item:immersiveengineering:nugget_aluminum>);
+//craftingTable.removeRecipe(<item:immersiveengineering:ingot_aluminum>);
+//craftingTable.removeRecipe(<item:immersiveengineering:storage_aluminum>);
+//
+//craftingTable.addShapeless("aluingottoblock",<item:immersiveengineering:storage_aluminum>,[<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>,<tag:items:forge:ingots/aluminum>]);
+//craftingTable.addShapeless("alublocktoingot",<item:immersiveengineering:ingot_aluminum>*9,[<tag:items:forge:storage_blocks/aluminum>]);
+//craftingTable.addShapeless("aluingottonugget",<item:immersiveengineering:nugget_aluminum>*9,[<tag:items:forge:ingots/aluminum>]);
+//craftingTable.addShapeless("alunuggettoingot",<item:immersiveengineering:ingot_aluminum>,[<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>,<tag:items:forge:nuggets/aluminum>]);
+//
 // Tin
-<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingottin>);
-<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingottin>);
+//<recipetype:minecraft:blasting>.removeRecipe(<item:libvulpes:ingottin>);
+//<recipetype:minecraft:smelting>.removeRecipe(<item:libvulpes:ingottin>);
 
-craftingTable.removeRecipe(<item:libvulpes:ingottin>);
-craftingTable.removeRecipe(<item:libvulpes:nuggettin>);
-craftingTable.removeRecipe(<item:libvulpes:blocktin>);
+//craftingTable.removeRecipe(<item:libvulpes:ingottin>);
+//craftingTable.removeRecipe(<item:libvulpes:nuggettin>);
+//craftingTable.removeRecipe(<item:libvulpes:blocktin>);


### PR DESCRIPTION
Any scripts that contained libvulpes or advanced rocketry have been commented out. Probably. Also removed all the custom fuel/kerosene liquids and such because those aren't needed either. 